### PR TITLE
Add rms-only option with scaling

### DIFF
--- a/main.c
+++ b/main.c
@@ -52,7 +52,7 @@ int main (int argc, char *argv[])
 	int c;
 	int spacing;
 	
-	while((c = getopt(argc, argv, "o:i:d:htms:a:leb:r:p:c:x:g:v")) != -1)
+	while((c = getopt(argc, argv, "o:i:d:htmjs:a:leb:r:p:c:x:g:v")) != -1)
 	{
 		switch (c)
 		{
@@ -82,6 +82,10 @@ int main (int argc, char *argv[])
 				break;
 			case 'e': // draw mark for every minute
 				options->drawMarkEveryMinute = true;
+				break;
+
+			case 'j': // rms-only draw mode (scale rms to height)
+				options->scaleRms = true;
 				break;
 			
 			case 's': // channel spacing
@@ -239,6 +243,7 @@ OPTIONS:\n\
    -i file    specify input file\n\n\
    -d dim     specify dimension as [width]x[height]. Default: %dx%d\n\
    -t         transparent background\n\
+   -j rms-only draw mode. Do not draw peak. Scale rms to height.\n\
    -b RRGGBB  specify background color. Default: %X%X%X\n\
    -r RRGGBB  specify rms color. Default: %X%X%X\n\
    -p RRGGBB  specify peak color. Default: %X%X%X\n\n\

--- a/waveformgen.h
+++ b/waveformgen.h
@@ -46,6 +46,8 @@ struct wfg_options {
 	int markSpacing;
 	
 	bool drawMarkEveryMinute;
+
+	bool scaleRms;
 };
 
 typedef struct wfg_options WFGO;


### PR DESCRIPTION
I've been using a pre-compiled version of waveformgen (of unknown origin) that had this "-j" option, which draws only rms and scales it to image height. However, it wouldn't run on modern distros. 

It seems your repo (and public forks I could find on github) didn't have this option, so to get this functionality back I had to add it myself. 

I kept it as "-j" for consistency, though I'm not sure why that letter was used. "-r" might make more sense. 

Not sure if you're still actively using/maintaining this repo but in the spirit of the GPL, here are my changes. 